### PR TITLE
P4-2802: move index alias creation before data indexing.

### DIFF
--- a/cmd/rp-indexer/main.go
+++ b/cmd/rp-indexer/main.go
@@ -110,6 +110,16 @@ func main() {
 			continue
 		}
 
+		// if the index didn't previously exist or we are rebuilding, remap to our alias
+		if remapAlias {
+			err := indexer.MapIndexAlias(config.ElasticURL, config.Index, physicalIndex)
+			if err != nil {
+				logError(config.Rebuild, err, "error remapping alias")
+				continue
+			}
+			remapAlias = false
+		}
+
 		start := time.Now()
 		log.WithField("last_modified", lastModified).WithField("index", physicalIndex).Info("indexing contacts newer than last modified")
 
@@ -120,16 +130,6 @@ func main() {
 			continue
 		}
 		log.WithField("added", indexed).WithField("deleted", deleted).WithField("index", physicalIndex).WithField("elapsed", time.Now().Sub(start)).Info("completed indexing")
-
-		// if the index didn't previously exist or we are rebuilding, remap to our alias
-		if remapAlias {
-			err := indexer.MapIndexAlias(config.ElasticURL, config.Index, physicalIndex)
-			if err != nil {
-				logError(config.Rebuild, err, "error remapping alias")
-				continue
-			}
-			remapAlias = false
-		}
 
 		// cleanup our aliases if appropriate
 		if config.Cleanup {


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

<Reminder PR Title should be JIRA_NUMBER and Useful Description>

## Summary
Description of changes.

#### Release Note
<Concise sentence describing change>Required.

#### Breaking Changes
<Description for Techops of how to handle changes, migrations, updates>None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

using an engage stack with no existing db yet, starting this container before the db has been initialized will not result in dozens of empty indexes being created for "today" eating up all available shards until such a time as the db has been initialized. (used cerebro to view indexes and shard allocation)
```
  admin_es:
    container_name: admin_es
    image: yannart/cerebro:latest
    ports:
      - 9001:9000
    environment:
      - AUTH_TYPE=basic
      - BASIC_AUTH_USER=${ADMIN_NAME}
      - BASIC_AUTH_PWD=${ADMIN_PSWD}
    volumes:
      -  ./res/cerebro.conf:/opt/cerebro/conf/application.conf
    depends_on:
      - elasticsearch
    restart: always
```
